### PR TITLE
feat: add richContent field for sending image

### DIFF
--- a/QuickPush/Models/PushNotification.swift
+++ b/QuickPush/Models/PushNotification.swift
@@ -23,6 +23,7 @@ struct PushNotification: Codable {
   let categoryId: String?
   let mutableContent: Bool?
   let contentAvailable: Bool?
+  let richContent: RichContent?
   
   enum Priority: String, Codable {
     case `default`, normal, high
@@ -30,6 +31,10 @@ struct PushNotification: Codable {
   
   enum InterruptionLevel: String, Codable {
     case active, critical, passive, timeSensitive = "time-sensitive"
+  }
+
+  struct RichContent: Codable {
+    let image: String
   }
   
   enum CodingKeys: String, CodingKey {
@@ -39,6 +44,7 @@ struct PushNotification: Codable {
     case categoryId = "categoryId"
     case mutableContent = "mutableContent"
     case contentAvailable = "_contentAvailable"
+    case richContent
   }
   
   init(
@@ -56,7 +62,8 @@ struct PushNotification: Codable {
     channelId: String? = nil,
     categoryId: String? = nil,
     mutableContent: Bool? = false,
-    contentAvailable: Bool? = nil
+    contentAvailable: Bool? = nil,
+    richContent: RichContent? = nil
   ) {
     self.to = to
     self.title = title
@@ -73,5 +80,6 @@ struct PushNotification: Codable {
     self.categoryId = categoryId
     self.mutableContent = mutableContent
     self.contentAvailable = contentAvailable
+    self.richContent = richContent
   }
 }


### PR DESCRIPTION
I added the richContent attribute so we can also test the implementation with images.
I also added a warning that this isn't supported by default on iOS.

What do you think ? 

https://github.com/user-attachments/assets/feb7300d-597d-40e1-8a2f-c1367415dc58

